### PR TITLE
Upadte responsive

### DIFF
--- a/css/fixed/about.css
+++ b/css/fixed/about.css
@@ -84,9 +84,45 @@
   color: white;
 }
 
-@media (max-width: 992px) {
+.btn-office {
+  margin-bottom: 1rem;
+  align-items: center;
+}
+
+/*---- VERSION IMAGE ---*/
+.portrait--little .row{
+  padding-bottom: 2rem;
+}
+
+.portrait--little .portrait-image {
+  max-width: 250px;
+  height: 250px;
+}
+
+.portrait--little .portrait-name {
+  left: 0;
+}
+
+/*---- Responsive ---*/
+
+@media (max-width: 1024px) {
   .mypage {
     margin-top: 2rem;
+    font-size: 1rem;
+  }
+
+  .portrait .flex {
+    justify-content: flex-start;
+  }
+
+  .portrait .flex > * {
+    margin-right: auto;
+  }
+
+  .portrait .social-icon,
+  .portrait .btn,
+  .portrait a {
+    margin-right: 1rem !important;
   }
 
   .portrait-name {
@@ -94,14 +130,15 @@
     margin: 0;
     padding: 0.8rem;
     width: 100%;
+    font-size: 1.75rem;
   }
   .portrait-title {
     margin-top: 1rem;
-    font-size: 1.75rem;
+    font-size: 1.5rem;
   }
 
   .portrait-lab {
-    font-size: 1.25rem;
+    font-size: 1rem;
   }
 
   .portrait-name {
@@ -115,18 +152,37 @@
   .portrait .btn {
     margin-bottom: 0.25rem;
   }
+
+  .portrait-image {
+    max-width: 200px;
+    height: 200px;
+  }
+
+  .about p {
+    line-height: 1.5rem;
+  }
 }
 
-/*---- VERSION IMAGE Little ---*/
-.portrait--little .row{
-  padding-bottom: 2rem;
+@media (max-width: 1024px) and (min-width: 768px) {
+  .flex-image-text {
+    display: flex;
+    justify-content: left;
+  }
+
+  .portrait--little .portrait-image {
+    margin: 0 1rem 0 0;
+  }
 }
 
-.portrait--little .portrait-image{
-  max-width: 250px;
-  height: 250px;
+@media (min-width: 1024px) and (max-width: 1224px) {
+  .flex-image-text {
+    display: flex;
+    justify-content: left;
+  }
+
+  .portrait-image {
+    max-width: 100%;
+    height: 100%;
+  }
 }
 
-.portrait--little .portrait-name {
-  left: 0;
-}

--- a/css/fixed/associations.css
+++ b/css/fixed/associations.css
@@ -20,7 +20,7 @@
   margin: 0 auto;
 }
 
-@media (max-width: 992px) {
+@media (max-width: 1024px) {
   .associations-list a{
     min-width: 100%;
    }

--- a/css/fixed/layout.css
+++ b/css/fixed/layout.css
@@ -26,14 +26,14 @@ main {
   justify-content: left !important;
 }
 
-@media (max-width: 992px) {
+@media (max-width: 1224px) {
   .header-light .header-light-content .logo{
     margin: 0 !important;
   }
 
   .nopadding {
-    padding: 0 !important;
-    margin: 0 !important;
+    padding: 3% !important;
+    margin: auto !important;
   }
 }
 
@@ -53,6 +53,12 @@ dt {
   min-width: 160px;
 }
 
+@media (max-width: 1224px) {
+  dt {
+    min-width: 80px;
+  }
+}
+
 
 .footer-light .image-faculity {
   bottom: 0;
@@ -66,16 +72,56 @@ hr {
   margin: 0;
 }
 
-@media (max-width: 992px) {
+@media (max-width: 1024px) {
   hr {
-    margin: 2rem;
+    margin: 2rem 0 0;
   }
 
   h3  {
-    font-size: 2rem;
+    font-size: 1.75rem;
   }
 
   .block {
-    margin-top: 3rem;
+    margin-top: 2rem;
+  }
+
+  .picture .img-fluid {
+    max-width: auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .footer-light-socials,
+  .logos,
+  .footer-light .list-inline {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .footer-light-socials span,
+  .footer-light-socials {
+    padding-top: 1rem;
+  }
+
+  .footer-legal-links {
+    margin-bottom: 1rem;
+  }
+
+  .footer-light .logos a:nth-child(2) img {
+    top: 20px;
+  }
+
+  .contact-title {
+    display: none;
+  }
+
+  .footer-light .list-inline-item {
+    padding: 0 !important;
+    margin-right: 1rem;
+  }
+
+  .logos a{
+    width: 50%;
   }
 }

--- a/css/fixed/press-coverages.css
+++ b/css/fixed/press-coverages.css
@@ -19,7 +19,7 @@
   border: 1px solid rgba(33, 33, 33, 0.125);
 }
 
-@media (max-width: 992px) {
+@media (max-width: 1024px) {
   .press-coverage {
     margin-bottom: 2rem;
   }

--- a/examples/version-image-medium.html
+++ b/examples/version-image-medium.html
@@ -42,7 +42,7 @@
     </header>
     <section class="container-fluid portrait portrait--medium">
       <div class="row">
-        <div class="col-lg-6 col-xl-4 nopadding">
+        <div class="col-lg-4 col-xl-4 nopadding">
           <div class="portrait-image">
             <picture>
               <!-- Your profile photo --><img src="../img/exemple-profile.jpg" class="img-fluid"
@@ -50,7 +50,7 @@
             </picture>
           </div>
         </div>
-        <div class="col-lg-6 col-xl-6">
+        <div class="col-lg-8 col-xl-6">
           <p class="mypage">IC People</p>
 
           <!-- Your firstname and surname -->
@@ -62,27 +62,26 @@
             Computer-Human Interaction Lab for Learning & Instruction
           </h3>
           <dl class="definition-list definition-list-grid">
-            <dt>Bureau</dt>
-            <dd>
-              <a class="btn btn-sm btn-secondary mr-2" href="">BM 42</a>
-              <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+            <!-- Office Contact -->
+            <dt>EPFL Contact</dt>
+            <dd class="flex">
+              <a href="mailto:samuel.hayden@epfl.ch" class="btn btn-sm btn-primary">samuel.hayden@epfl.ch</a>
             </dd>
-            <dt>Address</dt>
+            <dt>Office</dt>
             <dd>
+              <div class="flex btn-office">
+                <a class="btn btn-sm btn-secondary mr-2" href="#">BM 42</a>
+                <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+              </div>
               <a href="https://www.epfl.ch/labs/chili/contact/" class="portrait-infos-address">EPFL, IC, CHILI,<wbr /> Station 14
                 <br />
                 CH 1015 Lausanne <wbr />Switzerland</a>
             </dd>
-            <!-- Professional Contact -->
-            <dt>EPFL Contact</dt>
-            <dd class="flex">
-              <a href="mailto:samuel.hayden@epfl.ch" class="btn btn-sm btn-primary">samuel.hayden@epfl.ch</a>
-              <a href="tel:+41216939999" class="btn btn-sm btn-secondary">+41 21 693 99 99</a><br />
-            </dd>
+            <!-- Personal Contact -->
             <dt>Personal Contact</dt>
             <dd class="flex">
-              <a href="mailto:samuel.hayden@gmail.com">samuel.hayden@gmail.com</a>
-              <a href="tel:+41799990010">+41 79 999 00 10</a>
+              <a href="mailto:samuel.hayden@gmail.com" class="btn btn-sm btn-primary">samuel.hayden@gmail.com</a>
+              <a href="tel:+41799990010" class="btn btn-sm btn-secondary">+41 79 999 00 10</a>
             </dd>
           </dl>
           <div class="flex">
@@ -494,7 +493,7 @@
       <div class="container">
         <footer class="footer-light">
           <div class="row">
-            <div class="col-6 mx-auto mx-md-0 mb-4 col-md-3 col-lg-2">
+            <div class="mx-auto mx-md-0 mb-4 col-md-3 col-lg-2 logos">
               <a href="www.epfl.ch" target="_blank">
                 <img src="../img/fixed/EPFL_logo.png" alt="Logo EPFL, Ecole polytechnique fédérale de Lausanne"
                   class="img-fluid" />
@@ -507,7 +506,7 @@
             <div class="col-md-9 col-lg-10 mb-4">
               <div class="ml-md-2 ml-lg-5">
                 <ul class="list-inline list-unstyled">
-                  <li class="list-inline-item">Contact</li>
+                  <li class="list-inline-item contact-title">Contact</li>
                   <li class="list-inline-item text-muted pl-3">
                     <small>EPFL CH-1015 Lausanne</small>
                   </li>

--- a/examples/version-image-small.html
+++ b/examples/version-image-small.html
@@ -45,7 +45,7 @@
     <section class="container portrait portrait--little">
       <div class="row ">
         <div class="col-lg-12">
-          <div class="flex">
+          <div class="flex flex-image-text">
             <div class="portrait-image">
               <picture>
                 <!-- Your profile photo --><img src="../img/exemple-profile.jpg" class="img-fluid"
@@ -66,27 +66,26 @@
             </div>
           </div>
           <dl class="definition-list definition-list-grid">
-            <dt>Bureau</dt>
-            <dd>
-              <a class="btn btn-sm btn-secondary mr-2" href="">BM 42</a>
-              <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+            <!-- Office Contact -->
+            <dt>EPFL Contact</dt>
+            <dd class="flex">
+              <a href="mailto:samuel.hayden@epfl.ch" class="btn btn-sm btn-primary">samuel.hayden@epfl.ch</a>
             </dd>
-            <dt>Address</dt>
+            <dt>Office</dt>
             <dd>
+              <div class="flex btn-office">
+                <a class="btn btn-sm btn-secondary mr-2" href="#">BM 42</a>
+                <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+              </div>
               <a href="https://www.epfl.ch/labs/chili/contact/" class="portrait-infos-address">EPFL, IC, CHILI,<wbr /> Station 14
                 <br />
                 CH 1015 Lausanne <wbr />Switzerland</a>
             </dd>
-            <!-- Professional Contact -->
-            <dt>EPFL Contact</dt>
-            <dd class="flex">
-              <a href="mailto:samuel.hayden@epfl.ch" class="btn btn-sm btn-primary">samuel.hayden@epfl.ch</a>
-              <a href="tel:+41216939999" class="btn btn-sm btn-secondary">+41 21 693 99 99</a><br />
-            </dd>
+            <!-- Personal Contact -->
             <dt>Personal Contact</dt>
             <dd class="flex">
-              <a href="mailto:samuel.hayden@gmail.com">samuel.hayden@gmail.com</a>
-              <a href="tel:+41799990010">+41 79 999 00 10</a>
+              <a href="mailto:samuel.hayden@gmail.com" class="btn btn-sm btn-primary">samuel.hayden@gmail.com</a>
+              <a href="tel:+41799990010" class="btn btn-sm btn-secondary">+41 79 999 00 10</a>
             </dd>
           </dl>
           <!-- Your social medias -->
@@ -498,7 +497,7 @@
       <div class="container">
         <footer class="footer-light">
           <div class="row">
-            <div class="col-6 mx-auto mx-md-0 mb-4 col-md-3 col-lg-2">
+            <div class="mx-auto mx-md-0 mb-4 col-md-3 col-lg-2 logos">
               <a href="www.epfl.ch" target="_blank">
                 <img src="../img/fixed/EPFL_logo.png" alt="Logo EPFL, Ecole polytechnique fédérale de Lausanne"
                   class="img-fluid" />
@@ -511,7 +510,7 @@
             <div class="col-md-9 col-lg-10 mb-4">
               <div class="ml-md-2 ml-lg-5">
                 <ul class="list-inline list-unstyled">
-                  <li class="list-inline-item">Contact</li>
+                  <li class="list-inline-item contact-title">Contact</li>
                   <li class="list-inline-item text-muted pl-3">
                     <small>EPFL CH-1015 Lausanne</small>
                   </li>

--- a/examples/version-layout-master.html
+++ b/examples/version-layout-master.html
@@ -42,7 +42,7 @@
     </header>
     <section class="container-fluid portrait portrait--medium">
       <div class="row">
-        <div class="col-lg-3 col-xl-4 nopadding">
+        <div class="col-lg-4 col-xl-4 nopadding">
           <div class="portrait-image">
             <picture>
               <!-- Your profile photo --><img src="../img/exemple-profile.jpg" class="img-fluid"
@@ -50,7 +50,7 @@
             </picture>
           </div>
         </div>
-        <div class="col-lg-9 col-xl-6">
+        <div class="col-lg-8 col-xl-6">
           <p class="mypage">IC People</p>
 
           <!-- Your firstname and surname -->

--- a/examples/version-layout-master.html
+++ b/examples/version-layout-master.html
@@ -42,7 +42,7 @@
     </header>
     <section class="container-fluid portrait portrait--medium">
       <div class="row">
-        <div class="col-lg-6 col-xl-4 nopadding">
+        <div class="col-lg-3 col-xl-4 nopadding">
           <div class="portrait-image">
             <picture>
               <!-- Your profile photo --><img src="../img/exemple-profile.jpg" class="img-fluid"
@@ -50,7 +50,7 @@
             </picture>
           </div>
         </div>
-        <div class="col-lg-6 col-xl-6">
+        <div class="col-lg-9 col-xl-6">
           <p class="mypage">IC People</p>
 
           <!-- Your firstname and surname -->
@@ -62,27 +62,26 @@
             Computer-Human Interaction Lab for Learning & Instruction
           </h3>
           <dl class="definition-list definition-list-grid">
-            <dt>Bureau</dt>
-            <dd>
-              <a class="btn btn-sm btn-secondary mr-2" href="">BM 42</a>
-              <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+            <!-- Office Contact -->
+            <dt>EPFL Contact</dt>
+            <dd class="flex">
+              <a href="mailto:samuel.hayden@epfl.ch" class="btn btn-sm btn-primary">samuel.hayden@epfl.ch</a>
             </dd>
-            <dt>Address</dt>
+            <dt>Office</dt>
             <dd>
+              <div class="flex btn-office">
+                <a class="btn btn-sm btn-secondary mr-2" href="#">BM 42</a>
+                <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+              </div>
               <a href="https://www.epfl.ch/labs/chili/contact/" class="portrait-infos-address">EPFL, IC, CHILI,<wbr /> Station 14
                 <br />
                 CH 1015 Lausanne <wbr />Switzerland</a>
             </dd>
-            <!-- Professional Contact -->
-            <dt>EPFL Contact</dt>
-            <dd class="flex">
-              <a href="mailto:samuel.hayden@epfl.ch" class="btn btn-sm btn-primary">samuel.hayden@epfl.ch</a>
-              <a href="tel:+41216939999" class="btn btn-sm btn-secondary">+41 21 693 99 99</a><br />
-            </dd>
+            <!-- Personal Contact -->
             <dt>Personal Contact</dt>
             <dd class="flex">
-              <a href="mailto:samuel.hayden@gmail.com">samuel.hayden@gmail.com</a>
-              <a href="tel:+41799990010">+41 79 999 00 10</a>
+              <a href="mailto:samuel.hayden@gmail.com" class="btn btn-sm btn-primary">samuel.hayden@gmail.com</a>
+              <a href="tel:+41799990010" class="btn btn-sm btn-secondary">+41 79 999 00 10</a>
             </dd>
           </dl>
           <div class="flex">
@@ -236,7 +235,7 @@
       <div class="container">
         <footer class="footer-light">
           <div class="row">
-            <div class="col-6 mx-auto mx-md-0 mb-4 col-md-3 col-lg-2">
+            <div class="mx-auto mx-md-0 mb-4 col-md-3 col-lg-2 logos">
               <a href="www.epfl.ch" target="_blank">
                 <img src="../img/fixed/EPFL_logo.png" alt="Logo EPFL, Ecole polytechnique fédérale de Lausanne"
                   class="img-fluid" />
@@ -249,7 +248,7 @@
             <div class="col-md-9 col-lg-10 mb-4">
               <div class="ml-md-2 ml-lg-5">
                 <ul class="list-inline list-unstyled">
-                  <li class="list-inline-item">Contact</li>
+                  <li class="list-inline-item contact-title">Contact</li>
                   <li class="list-inline-item text-muted pl-3">
                     <small>EPFL CH-1015 Lausanne</small>
                   </li>

--- a/examples/version-minimal.html
+++ b/examples/version-minimal.html
@@ -49,7 +49,7 @@
       <div class="container">
         <footer class="footer-light">
           <div class="row">
-            <div class="col-6 mx-auto mx-md-0 mb-4 col-md-3 col-lg-2">
+            <div class="mx-auto mx-md-0 mb-4 col-md-3 col-lg-2 logos">
               <a href="www.epfl.ch" target="_blank">
                 <img src="../img/fixed/EPFL_logo.png" alt="Logo EPFL, Ecole polytechnique fédérale de Lausanne"
                   class="img-fluid" />
@@ -62,7 +62,7 @@
             <div class="col-md-9 col-lg-10 mb-4">
               <div class="ml-md-2 ml-lg-5">
                 <ul class="list-inline list-unstyled">
-                  <li class="list-inline-item">Contact</li>
+                  <li class="list-inline-item contact-title">Contact</li>
                   <li class="list-inline-item text-muted pl-3">
                     <small>EPFL CH-1015 Lausanne</small>
                   </li>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
       </header>
       <section class="container-fluid portrait">
         <div class="row">
-          <div class="col-md-6 nopadding">
+          <div class="col-lg-4 col-xl-6 nopadding">
             <div class="portrait-image">
               <picture>
                 <!-- Your profile photo -->
@@ -63,7 +63,7 @@
               </picture>
             </div>
           </div>
-          <div class="col-md-6">
+          <div class="col-lg-8 col-xl-6">
             <p class="mypage">IC People</p>
 
             <!-- Your firstname and surname -->
@@ -76,22 +76,7 @@
               Computer-Human Interaction Lab for Learning & Instruction
             </h3>
             <dl class="definition-list definition-list-grid">
-              <dt>Bureau</dt>
-              <dd>
-                <a class="btn btn-sm btn-secondary mr-2" href="">BM 42</a>
-                <a href="tel:+41216939999">+41 21 693 99 99</a><br />
-              </dd>
-              <!-- Postal address of epfl-->
-              <dt>Address</dt>
-              <dd>
-                <a
-                  href="https://www.epfl.ch/labs/chili/contact/"
-                  class="portrait-infos-address"
-                  >EPFL, IC, CHILI,<wbr /> Station 14 <br />
-                  CH 1015 Lausanne <wbr />Switzerland</a
-                >
-              </dd>
-              <!-- Professional Contact -->
+              <!-- Office Contact -->
               <dt>EPFL Contact</dt>
               <dd class="flex">
                 <a
@@ -99,15 +84,25 @@
                   class="btn btn-sm btn-primary"
                   >samuel.hayden@epfl.ch</a
                 >
-                <a href="tel:+41216939999" class="btn btn-sm btn-secondary"
-                  >+41 21 693 99 99</a
-                ><br />
+              </dd>
+              <dt>Office</dt>
+              <dd>
+                <div class="flex btn-office">
+                  <a class="btn btn-sm btn-secondary mr-2" href="#">BM 42</a>
+                  <a href="tel:+41216939999">+41 21 693 99 99</a><br />
+                </div>
+                <a
+                  href="https://www.epfl.ch/labs/chili/contact/"
+                  class="portrait-infos-address"
+                  >EPFL, IC, CHILI,<wbr /> Station 14 <br />
+                  CH 1015 Lausanne <wbr />Switzerland</a
+                >
               </dd>
               <!-- Personal Contact -->
               <dt>Personal Contact</dt>
             <dd class="flex">
-              <a href="mailto:samuel.hayden@gmail.com">samuel.hayden@gmail.com</a>
-              <a href="tel:+41799990010">+41 79 999 00 10</a>
+              <a href="mailto:samuel.hayden@gmail.com" class="btn btn-sm btn-primary">samuel.hayden@gmail.com</a>
+              <a href="tel:+41799990010" class="btn btn-sm btn-secondary">+41 79 999 00 10</a>
             </dd>
           </dl>
           <!-- Your social medias -->
@@ -597,7 +592,7 @@
       <div class="container">
         <footer class="footer-light">
           <div class="row">
-            <div class="col-6 mx-auto mx-md-0 mb-4 col-md-3 col-lg-2">
+            <div class="mx-auto mx-md-0 mb-4 col-md-3 col-lg-2 logos">
               <a href="www.epfl.ch" target="_blank">
                 <img src="./img/fixed/EPFL_logo.png" alt="Logo EPFL, Ecole polytechnique fédérale de Lausanne"
                   class="img-fluid" />
@@ -610,7 +605,7 @@
             <div class="col-md-9 col-lg-10 mb-4">
               <div class="ml-md-2 ml-lg-5">
                 <ul class="list-inline list-unstyled">
-                  <li class="list-inline-item">Contact</li>
+                  <li class="list-inline-item contact-title">Contact</li>
                   <li class="list-inline-item text-muted pl-3">
                     <small>EPFL CH-1015 Lausanne</small>
                   </li>


### PR DESCRIPTION
- header - la partie IC du logo est toujours à droite de l’écran dans les largeurs “tablette” (±990 à 1200px)
- pour les versions grande et moyenne image de profile: sur mobile elles sont énoooormes, je ne crois pas que ce soit nécessaire et j’imagine que d’avoir la même taille que la petite version sur mobile irait très bien. (tu pourrais demander l’avis de Guillaume demain, vu qu’il sera le seul designer ou encore de Marc ou Gilles !)
- Version petite image de profile:  breaking point de desktop à tablette me paraît arriver très tôt, non ? j’ai l’impression qu’on pourrait avoir l’image à côté du nom et titre avec une largeur moins grande de fenêtre. T’en dis quoi ?
- les flèches “gauche droite” pour les publications apparaissent par dessus “learn more & apply”, étrange ! Est-ce que le bouton rouge devrait être dans la box du contenu en dessus (EPFL Drone days) ?
- Footer
- les logos EPFL et IC ne sont pas toujours bien alignés en responsive
- mobile : le passage à ligne du numéro de téléphone est aligné bizarrement. si possible de l’aligner avec “EPFL  CH1015…” ? (pas gravissime car ca va peut être changer)
- socials :sur mobile  est-ce que ce serait pas mieux d’avoir les icônes alignées sous le texte “follow the pulses…“, plutôt que d’avoir une colonne texte et une colonne d’icônes ?
- tableau de contact
- Je mettrais a ligne “EPFL contact” en premier, avec le même contenu
	- Ensuite une ligne “Office” avec dedans
	- la box “BM 402”
	- et (en dessous) l’adresse
	- le numéro de téléphone du bureau est déjà indiqué dans EPFL contact, donc pas besoin de le remettre.
- Finalement “Personal contact”, avec le même layout pour l’email et le numéro de téléphone qu’utilisé sur la ligne “epfl contact”